### PR TITLE
Add VarSkip to index, update to latest schema

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -1,3 +1,4 @@
+schema_version: 1-0-0
 metadata: The PHA4GE list of amplicon primer schemes
 repository: "https://github.com/pha4ge/primer-schemes"
 latest_doi: "https://doi.coming.soon/"

--- a/index.yml
+++ b/index.yml
@@ -7,7 +7,6 @@ schemes:
     organism: SARS-CoV-2
     aliases:
       -  ARTIC-SARS-CoV-2
-    latest_version: "v4.1"
     versions:
       - version: "v1"
         repository: "https://raw.githubusercontent.com/PHA4GE/primer-schemes/main/sars-cov-2/artic/v1"
@@ -29,7 +28,6 @@ schemes:
         repository: "https://raw.githubusercontent.com/PHA4GE/primer-schemes/main/sars-cov-2/artic/v5.2.0_400"
   - name: Eden
     organism: SARS-CoV-2
-    latest_version: "v1"
     versions:
       - version: "v1"
         repository: "https://raw.githubusercontent.com/PHA4GE/primer-schemes/main/sars-cov-2/eden/v1"
@@ -50,9 +48,19 @@ schemes:
         repository: https://raw.githubusercontent.com/PHA4GE/primer-schemes/main/sars-cov-2/midnight/bccdc-v4
       - version: ont-v3
         repository: https://raw.githubusercontent.com/PHA4GE/primer-schemes/main/sars-cov-2/midnight/ont-v3
+  - name: VarSkip
+    organism: SARS-CoV-2
+    versions:
+    - version: vss1a
+      repository: https://raw.githubusercontent.com/PHA4GE/primer-schemes/main/sars-cov-2/varskip/vss1a
+    - version: vsl1a
+      repository: https://raw.githubusercontent.com/PHA4GE/primer-schemes/main/sars-cov-2/varskip/vsl1a
+    - version: vss2a
+      repository: https://raw.githubusercontent.com/PHA4GE/primer-schemes/main/sars-cov-2/varskip/vss2a
+    - version: vss2b
+      repository: https://raw.githubusercontent.com/PHA4GE/primer-schemes/main/sars-cov-2/varskip/vss2b
   - name: yale
     organism: MPXV
-    latest_version: "v3"
     versions:
     - version: v3
       repository: https://raw.githubusercontent.com/PHA4GE/primer-schemes/main/mpxv/yale/v3

--- a/sars-cov-2/artic/v1/info.yaml
+++ b/sars-cov-2/artic/v1/info.yaml
@@ -1,4 +1,4 @@
-schema_version: 1-0-0
+schema_version: 1-0-1
 name: artic-v1
 organism: SARS-CoV-2
 organism_aliases:
@@ -12,5 +12,6 @@ amplicon_size: 400
 repository_url: https://github.com/pha4ge/primer-schemes/tree/main/sars-cov-2/artic/v1
 citations:
 - https://doi.org/10.1101%2F2020.09.04.283077
+deprecated: true
 primer_checksum: primaschema:e1560cb6d7bf5c0411d80f56e5d6b3fa4f5e4006b1bfaa745b18059c249d0403
 reference_checksum: primaschema:7d5621cd3b3e498d0c27fcca9d3d3c5168c7f3d3f9776f3005c7011bd90068ca

--- a/sars-cov-2/artic/v2/info.yaml
+++ b/sars-cov-2/artic/v2/info.yaml
@@ -1,4 +1,4 @@
-schema_version: 1-0-0
+schema_version: 1-0-1
 name: artic-v2
 organism: SARS-CoV-2
 organism_aliases:
@@ -13,5 +13,6 @@ repository_url: https://github.com/pha4ge/primer-schemes/tree/main/sars-cov-2/ar
 citations:
 - https://doi.org/10.1101%2F2020.09.04.283077
 derived_from: artic-v1
+deprecated: true
 primer_checksum: primaschema:6b9e64d0968d826c637caa9df019d3bf157911592cf5f7506e6e8e7c5f191767
 reference_checksum: primaschema:7d5621cd3b3e498d0c27fcca9d3d3c5168c7f3d3f9776f3005c7011bd90068ca

--- a/sars-cov-2/artic/v3/info.yaml
+++ b/sars-cov-2/artic/v3/info.yaml
@@ -1,4 +1,4 @@
-schema_version: 1-0-0
+schema_version: 1-0-1
 name: artic-v3
 organism: SARS-CoV-2
 organism_aliases:
@@ -13,5 +13,6 @@ repository_url: https://github.com/pha4ge/primer-schemes/tree/main/sars-cov-2/ar
 citations:
 - https://doi.org/10.1101%2F2020.09.04.283077
 derived_from: artic-v2
+deprecated: true
 primer_checksum: primaschema:34ca07d9c616461fd7a1fae563188315a1fbfe7052bfbc4ee5d9ac8144ad8c56
 reference_checksum: primaschema:7d5621cd3b3e498d0c27fcca9d3d3c5168c7f3d3f9776f3005c7011bd90068ca

--- a/sars-cov-2/artic/v4/info.yaml
+++ b/sars-cov-2/artic/v4/info.yaml
@@ -13,5 +13,6 @@ repository_url: https://github.com/pha4ge/primer-schemes/tree/main/sars-cov-2/ar
 citations:
 - https://doi.org/10.1101%2F2020.09.04.283077
 derived_from: artic-v3
+deprecated: true
 primer_checksum: primaschema:2df872deb2123004c098c5c96610a14e5cdc7b8b27593e9a3ad2d37d9282543b
 reference_checksum: primaschema:7d5621cd3b3e498d0c27fcca9d3d3c5168c7f3d3f9776f3005c7011bd90068ca

--- a/sars-cov-2/midnight/bccdc-v1/info.yaml
+++ b/sars-cov-2/midnight/bccdc-v1/info.yaml
@@ -1,4 +1,4 @@
-schema_version: 1-0-0
+schema_version: 1-0-1
 name: midnight-bccdc-v1
 organism: SARS-CoV-2
 organism_aliases:
@@ -15,5 +15,6 @@ citations:
 - https://dx.doi.org/10.17504/protocols.io.bwyppfvn
 notes:
 - Accomodates P.1
+deprecated: true
 primer_checksum: primaschema:62f2d91308027480dd030e937dce767f2d5cda5a47297895b878e8b6facaac06
 reference_checksum: primaschema:7d5621cd3b3e498d0c27fcca9d3d3c5168c7f3d3f9776f3005c7011bd90068ca

--- a/sars-cov-2/midnight/bccdc-v2/info.yaml
+++ b/sars-cov-2/midnight/bccdc-v2/info.yaml
@@ -1,4 +1,4 @@
-schema_version: 1-0-0
+schema_version: 1-0-1
 name: midnight-bccdc-v2
 organism: SARS-CoV-2
 organism_aliases:
@@ -15,5 +15,6 @@ citations:
 - https://dx.doi.org/10.17504/protocols.io.bwyppfvn
 notes:
 - Accomodates BA.1
+deprecated: true
 primer_checksum: primaschema:50191ae0f7a45cf5f5e69253f76984cfffb81cf97751c8c696900f6a7d0cad18
 reference_checksum: primaschema:7d5621cd3b3e498d0c27fcca9d3d3c5168c7f3d3f9776f3005c7011bd90068ca

--- a/sars-cov-2/midnight/bccdc-v3/info.yaml
+++ b/sars-cov-2/midnight/bccdc-v3/info.yaml
@@ -1,4 +1,4 @@
-schema_version: 1-0-0
+schema_version: 1-0-1
 name: midnight-bccdc-v3
 organism: SARS-CoV-2
 organism_aliases:
@@ -13,5 +13,6 @@ amplicon_size: 1200
 repository_url: https://github.com/pha4ge/primer-schemes/tree/main/sars-cov-2/midnight/bccdc-v3
 citations:
 - https://dx.doi.org/10.17504/protocols.io.bwyppfvn
+deprecated: true
 primer_checksum: primaschema:3e118ebd83d1a8613490e23c452ccc85422dd95a2726b5f39e8b1b1c46261505
 reference_checksum: primaschema:7d5621cd3b3e498d0c27fcca9d3d3c5168c7f3d3f9776f3005c7011bd90068ca

--- a/sars-cov-2/midnight/v1/info.yaml
+++ b/sars-cov-2/midnight/v1/info.yaml
@@ -1,4 +1,4 @@
-schema_version: 1-0-0
+schema_version: 1-0-1
 name: midnight-v1
 organism: SARS-CoV-2
 organism_aliases:
@@ -18,5 +18,6 @@ amplicon_size: 1200
 repository_url: https://github.com/pha4ge/primer-schemes/tree/main/sars-cov-2/midnight/v1
 citations:
 - https://dx.doi.org/10.17504/protocols.io.bwyppfvn
+deprecated: true
 primer_checksum: primaschema:e1303ce0367cc245e66b80c10f8086c60f64b501e43dff0c0a248e64c34389b7
 reference_checksum: primaschema:7d5621cd3b3e498d0c27fcca9d3d3c5168c7f3d3f9776f3005c7011bd90068ca

--- a/sars-cov-2/midnight/v2/info.yaml
+++ b/sars-cov-2/midnight/v2/info.yaml
@@ -1,4 +1,4 @@
-schema_version: 1-0-0
+schema_version: 1-0-1
 name: midnight-v2
 organism: SARS-CoV-2
 organism_aliases:
@@ -22,5 +22,6 @@ notes:
 - Accomodates Omicron BA.1 with single primer addition
 - https://twitter.com/freed_nikki/status/1464477522448433156
 - Not considered a new version by Freed et al. and IDT despite additional primer
+deprecated: true
 primer_checksum: primaschema:8f733a1f180c435af14d88fa395df5f88e1e1e0e9bde2c0719af8111079afce5
 reference_checksum: primaschema:7d5621cd3b3e498d0c27fcca9d3d3c5168c7f3d3f9776f3005c7011bd90068ca

--- a/sars-cov-2/varskip/vss1a/info.yaml
+++ b/sars-cov-2/varskip/vss1a/info.yaml
@@ -1,4 +1,4 @@
-schema_version: 1-0-0
+schema_version: 1-0-1
 name: varskip-vss1a
 organism: SARS-CoV-2
 organism_aliases:
@@ -18,5 +18,6 @@ citations:
 notes:
 - Adapted from bed + tsv at https://github.com/nebiolabs/VarSkip with help from Brad Langhorst
 derived_from: artic-v3
+deprecated: true
 primer_checksum: primaschema:f0d4caf86103e5104d2d29d15ffa66d71a29a923dc094bb94dac3c80aef45059
 reference_checksum: primaschema:7d5621cd3b3e498d0c27fcca9d3d3c5168c7f3d3f9776f3005c7011bd90068ca


### PR DESCRIPTION
This PR:
1. Adds the VarSkip entries to the index
2. Removes the "latest_version" keys from the index (aka manifest)
3. Adds deprecated keys where appropriate in the scheme info yaml files

These last two items make the YAML files compliant with the latest schema as per this PR: https://github.com/pha4ge/primaschema/pull/8